### PR TITLE
Add Sabre support to processor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ protobuf = "2.8.1"
 cfg-if = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-sabre-sdk = "0.2"
+sabre-sdk = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-sawtooth-sdk = "0.2"
+sawtooth-sdk = "0.3"
 log = "0.4"
 log4rs = "0.8"

--- a/Dockerfile.sabre
+++ b/Dockerfile.sabre
@@ -1,0 +1,86 @@
+# Copyright (c) 2019 Target Brands, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:bionic as CONSENSOURCE-CONTRACT-BUILDER
+
+RUN apt-get update \
+&& apt-get install gnupg -y
+
+# Install base dependencies
+RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    build-essential \
+    curl \
+    gcc \
+    g++ \
+    libpq-dev \
+    libssl-dev \
+    libsasl2-dev \
+    libzmq3-dev \
+    openssl \
+    pkg-config \
+    sabre-cli \
+    unzip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=$PATH:/protoc3/bin:/root/.cargo/bin
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
+ && chmod +x /usr/bin/rustup-init \
+ && rustup-init -y
+
+RUN rustup update \
+ && rustup target add wasm32-unknown-unknown
+
+# Install protoc
+RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip \
+ && unzip -o protoc-3.7.1-linux-x86_64.zip -d /usr/local \
+ && rm protoc-3.7.1-linux-x86_64.zip
+
+RUN mkdir /build
+
+# Copy common dependency
+COPY common/ /build/common/
+
+# Create empty cargo project
+WORKDIR /build
+RUN USER=root cargo new --bin processor
+
+# Copy over Cargo.toml file
+COPY processor/Cargo.toml /build/processor/Cargo.toml
+
+# Do a release build to cache dependencies
+WORKDIR /build/processor
+RUN cargo build --release
+
+# Remove the auto-generated .rs files and the built files
+RUN rm src/*.rs
+RUN rm ./target/release/cert-registry-processor*
+#./target/release/consensource* ./target/release/deps/cert-registry* ./target/release/deps/consensource*
+
+# Copy over source files
+COPY processor/src /build/processor/src
+
+# Build the contract
+RUN cargo build --target wasm32-unknown-unknown --release
+
+# Copy the contract definition
+COPY processor/consensource.yaml /build/processor/consensource.yaml
+
+ENTRYPOINT []

--- a/cert_registry.yaml
+++ b/cert_registry.yaml
@@ -1,7 +1,0 @@
-name: cert_registry
-version: '0.1'
-wasm: processor/target/wasm32-unknown-unknown/release/cert_registry.wasm
-inputs:
-  - '439a56'
-outputs:
-  - '439a56'

--- a/consensource.yaml
+++ b/consensource.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2019 Target Brands, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: consensource
+version: "0.1"
+wasm: target/wasm32-unknown-unknown/release/cert-registry-processor.wasm
+inputs:
+  - "3d0111"
+outputs:
+  - "3d0111"

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -125,12 +125,10 @@ impl CertPayload {
                             "Factory must be created with an address",
                         )));
                     }
-                } else {
-                    if create_org.has_address() {
-                        return Err(ApplyError::InvalidTransaction(String::from(
-                            "Only a factory can have an address",
-                        )));
-                    }
+                } else if create_org.has_address() {
+                    return Err(ApplyError::InvalidTransaction(String::from(
+                        "Only a factory can have an address",
+                    )));
                 }
 
                 Action::CreateOrganization(create_org.clone())


### PR DESCRIPTION
## Proposed change/fix
Support already existed in the processor to use Sabre, this configures our Docker set up
- Add alternative `Dockerfile.sabre` to processor to compile to wasm
- Update `sabre-sdk` version to 0.4
- Add `consensource.yaml` contract definition file
- Update `sawtooth-sdk` to 0.3

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

Please include instructions on how to run/test your contribution. Tests are welcomed!
Disregard this if your contribution is less technical (little to no code).

`cargo build --target wasm32-unknown-unknown --release`