### PR TITLE
Update the Sabre Dockerfile to use consensource instead of cert-registry

### DIFF
--- a/Dockerfile.sabre
+++ b/Dockerfile.sabre
@@ -71,8 +71,7 @@ RUN cargo build --release
 
 # Remove the auto-generated .rs files and the built files
 RUN rm src/*.rs
-RUN rm ./target/release/cert-registry-processor*
-#./target/release/consensource* ./target/release/deps/cert-registry* ./target/release/deps/consensource*
+RUN rm ./target/release/consensource-processor*
 
 # Copy over source files
 COPY processor/src /build/processor/src


### PR DESCRIPTION
## Proposed change/fix

Bug fix to update name used to remove the auto-generated binary name when caching dependencies during the docker build.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test
In the compose repo:
`docker-compose -f docker-compose.sabre.yaml up --build consensource-contract-builder`
