### PR TITLE
Implement UpdateCertificate transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/target/consensource-common.git?branch=master#3f1c6eab7b6e304fdb849f14e4a78b0d0cb922fc"
+source = "git+https://github.com/target/consensource-common.git?branch=master#92fc1fe292e1eb6aad3a7c87ff08ae06aa72abfe"
 dependencies = [
  "glob",
  "protobuf",
@@ -166,9 +166,9 @@ checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 
 [[package]]
 name = "flate2"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
@@ -264,9 +264,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.83"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0c4e9c72ee9d69b767adebc5f4788462a3b45624acd919475c92597bcaf4f"
+checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
 
 [[package]]
 name = "linked-hash-map"
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "971be8f6e4d4a47163b405a3df70d14359186f9ab0f3a3ec37df144ca1ce089f"
+checksum = "bdd2af560da3c1fdc02cb80965289254fc35dff869810061e2d8290ee48848ae"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -885,9 +885,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wasi"
-version = "0.10.1+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "consensource-processor"
 version = "0.1.0"
+description = "A ConsenSource transaction family for Sawtooth"
+authors = [ "Target" ]
+license = "Apache-2.0"
 
 [dependencies]
 clap = "2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,39 @@
-FROM target/consensource-rust:stable
+# -------------=== processor build ===-------------
+FROM ubuntu:xenial as processor-rust-builder
 
-COPY . /processor
-WORKDIR processor
-RUN cargo build
+ENV VERSION=0.1.0
 
-ENV PATH=$PATH:/processor/target/debug/
+RUN apt-get update \
+ && apt-get install -y \
+ curl \
+ gcc \
+ git \
+ libssl-dev \
+ libzmq3-dev \
+ pkg-config \
+ python3 \
+ unzip
+
+# For Building Protobufs
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
+ && curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
+ && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \
+ && rm protoc-3.5.1-linux-x86_64.zip
+
+ENV PATH=$PATH:/protoc3/bin
+RUN /root/.cargo/bin/cargo install cargo-deb
+
+COPY . /project
+
+WORKDIR /project/
+
+RUN /root/.cargo/bin/cargo deb --deb-version $VERSION
+
+# -------------=== processor rust docker build ===-------------
+FROM ubuntu:xenial
+
+COPY --from=processor-rust-builder /project/target/debian/consensource-processor*.deb /tmp
+
+RUN apt-get update \
+ && dpkg -i /tmp/consensource-processor*.deb || true \
+ && apt-get -f -y install

--- a/src/handler/certificate.rs
+++ b/src/handler/certificate.rs
@@ -406,4 +406,141 @@ mod tests {
             )
         );
     }
+
+    #[test]
+    /// Test that if UpdateCertificateAction as a certifying body is valid an OK is returned and an existing Certificate is updated to state
+    fn test_update_certificate_as_cert_body_is_valid() {
+        let mut transaction_context = MockTransactionContext::default();
+        let mut state = ConsensourceState::new(&mut transaction_context);
+
+        // add agent
+        let standard_agent_action = make_agent_create_action();
+        agent::create(&standard_agent_action, &mut state, PUBLIC_KEY_1).unwrap();
+
+        // add org
+        let standard_org_action = make_organization_create_action(
+            STANDARDS_BODY_ID,
+            proto::organization::Organization_Type::STANDARDS_BODY,
+        );
+        organization::create(&standard_org_action, &mut state, PUBLIC_KEY_1).unwrap();
+
+        // add standard
+        let standard_action = make_standard_create_action();
+        standard::create(&standard_action, &mut state, PUBLIC_KEY_1).unwrap();
+
+        // add second agent
+        let factory_agent_action = make_agent_create_action();
+        agent::create(&factory_agent_action, &mut state, PUBLIC_KEY_2).unwrap();
+
+        // add factory org
+        let factory_org_action = make_organization_create_action(
+            FACTORY_ID,
+            proto::organization::Organization_Type::FACTORY,
+        );
+        organization::create(&factory_org_action, &mut state, PUBLIC_KEY_2).unwrap();
+
+        // add third agent
+        let cert_agent_action = make_agent_create_action();
+        agent::create(&cert_agent_action, &mut state, PUBLIC_KEY_3).unwrap();
+
+        // add certifying org
+        let cert_org_action = make_organization_create_action(
+            CERT_ORG_ID,
+            proto::organization::Organization_Type::CERTIFYING_BODY,
+        );
+        organization::create(&cert_org_action, &mut state, PUBLIC_KEY_3).unwrap();
+
+        // accredit the cert org
+        let accredit_action = make_accredit_certifying_body_action();
+        standard::accredit_certifying_body(&accredit_action, &mut state, PUBLIC_KEY_1).unwrap();
+
+        // issue (create) certificate
+        let issue_action = make_issue_certificate_action();
+        assert!(issue(&issue_action, &mut state, PUBLIC_KEY_3).is_ok());
+
+        // update certificate
+        let update_action = make_update_certificate_action();
+        assert!(update(&update_action, &mut state, PUBLIC_KEY_3).is_ok());
+
+        let certificate = state
+            .get_certificate(CERT_ID)
+            .expect("Failed to fetch certificate")
+            .expect("No certificate found");
+
+        assert_eq!(certificate, make_updated_certificate(CERT_ORG_ID));
+    }
+
+    #[test]
+    /// Test that if UpdateCertificateAction as an ingestion org is valid an OK is returned and an existing Certificate is updated to state
+    fn test_update_certificate_as_ingestion_org_is_valid() {
+        let mut transaction_context = MockTransactionContext::default();
+        let mut state = ConsensourceState::new(&mut transaction_context);
+
+        // add agent
+        let standard_agent_action = make_agent_create_action();
+        agent::create(&standard_agent_action, &mut state, PUBLIC_KEY_1).unwrap();
+
+        // add org
+        let standard_org_action = make_organization_create_action(
+            STANDARDS_BODY_ID,
+            proto::organization::Organization_Type::STANDARDS_BODY,
+        );
+        organization::create(&standard_org_action, &mut state, PUBLIC_KEY_1).unwrap();
+
+        // add standard
+        let standard_action = make_standard_create_action();
+        standard::create(&standard_action, &mut state, PUBLIC_KEY_1).unwrap();
+
+        // add second agent
+        let factory_agent_action = make_agent_create_action();
+        agent::create(&factory_agent_action, &mut state, PUBLIC_KEY_2).unwrap();
+
+        // add factory org
+        let factory_org_action = make_organization_create_action(
+            FACTORY_ID,
+            proto::organization::Organization_Type::FACTORY,
+        );
+        organization::create(&factory_org_action, &mut state, PUBLIC_KEY_2).unwrap();
+
+        // add third agent
+        let cert_agent_action = make_agent_create_action();
+        agent::create(&cert_agent_action, &mut state, PUBLIC_KEY_3).unwrap();
+
+        // add certifying org
+        let cert_org_action = make_organization_create_action(
+            CERT_ORG_ID,
+            proto::organization::Organization_Type::CERTIFYING_BODY,
+        );
+        organization::create(&cert_org_action, &mut state, PUBLIC_KEY_3).unwrap();
+
+        // accredit the cert org
+        let accredit_action = make_accredit_certifying_body_action();
+        standard::accredit_certifying_body(&accredit_action, &mut state, PUBLIC_KEY_1).unwrap();
+
+        // issue (create) certificate
+        let issue_action = make_issue_certificate_action();
+        assert!(issue(&issue_action, &mut state, PUBLIC_KEY_3).is_ok());
+
+        // add fourth agent
+        let ingestion_agent_action = make_agent_create_action();
+        agent::create(&ingestion_agent_action, &mut state, PUBLIC_KEY_4).unwrap();
+
+        // add ingestion org
+        let ingestion_org_action = make_organization_create_action(
+            INGESTION_ID,
+            proto::organization::Organization_Type::INGESTION,
+        );
+        organization::create(&ingestion_org_action, &mut state, PUBLIC_KEY_4).unwrap();
+
+        // update certificate
+        let update_action = make_update_certificate_action();
+        assert!(update(&update_action, &mut state, PUBLIC_KEY_4).is_ok());
+
+        let certificate = state
+            .get_certificate(CERT_ID)
+            .expect("Failed to fetch certificate")
+            .expect("No certificate found");
+
+        assert_eq!(certificate, make_updated_certificate(INGESTION_ID));
+    }
 }

--- a/src/handler/certificate.rs
+++ b/src/handler/certificate.rs
@@ -192,12 +192,12 @@ pub fn update(
     organization::check_authorization(&org, signer_public_key, TRANSACTOR)?;
 
     // Validate current valid_from/to dates
-    if certificate.get_valid_from() <= 0 {
+    if certificate.get_valid_from() == 0 {
         return Err(ApplyError::InvalidTransaction(
             "The valid_from date supplied was not valid".to_string(),
         ));
     }
-    if certificate.get_valid_to() <= 0 {
+    if certificate.get_valid_to() == 0 {
         return Err(ApplyError::InvalidTransaction(
             "The valid_to date supplied was not valid".to_string(),
         ));
@@ -216,7 +216,7 @@ pub fn update(
     certificate.set_valid_to(valid_to);
 
     // Update state
-    state.set_certificate(&certificate.clone().get_id(), certificate)?;
+    state.set_certificate(&certificate.get_id(), certificate.clone())?;
 
     Ok(())
 }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -92,6 +92,9 @@ impl TransactionHandler for ConsensourceTransactionHandler {
             Action::IssueCertificate(payload) => {
                 certificate::issue(&payload, &mut state, signer_public_key)
             }
+            Action::UpdateCertificate(payload) => {
+                certificate::update(&payload, &mut state, signer_public_key)
+            }
             Action::CreateStandard(payload) => {
                 standard::create(&payload, &mut state, signer_public_key)
             }

--- a/src/handler/organization.rs
+++ b/src/handler/organization.rs
@@ -110,7 +110,7 @@ pub fn update(
         ));
     }
 
-    state.set_organization(&organization.clone().get_id(), organization)?;
+    state.set_organization(&organization.get_id(), organization.clone())?;
     Ok(())
 }
 

--- a/src/handler/test_utils.rs
+++ b/src/handler/test_utils.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 pub const PUBLIC_KEY_1: &str = "test_public_key_1";
 pub const PUBLIC_KEY_2: &str = "test_public_key_2";
 pub const PUBLIC_KEY_3: &str = "test_public_key_3";
+pub const PUBLIC_KEY_4: &str = "test_public_key_4";
 pub const CERT_ORG_ID: &str = "test_cert_org";
 pub const FACTORY_ID: &str = "test_factory";
 pub const STANDARDS_BODY_ID: &str = "test_standards_body";
@@ -184,6 +185,19 @@ pub fn make_certificate(cert_org_id: &str) -> proto::certificate::Certificate {
     new_certificate.set_standard_version("test".to_string());
     new_certificate.set_valid_from(1);
     new_certificate.set_valid_to(2);
+
+    new_certificate
+}
+
+pub fn make_updated_certificate(cert_org_id: &str) -> proto::certificate::Certificate {
+    let mut new_certificate = proto::certificate::Certificate::new();
+    new_certificate.set_id(CERT_ID.to_string());
+    new_certificate.set_certifying_body_id(cert_org_id.to_string());
+    new_certificate.set_factory_id(FACTORY_ID.to_string());
+    new_certificate.set_standard_id(STANDARD_ID.to_string());
+    new_certificate.set_standard_version("test".to_string());
+    new_certificate.set_valid_from(1);
+    new_certificate.set_valid_to(3);
 
     new_certificate
 }
@@ -362,6 +376,14 @@ pub fn make_issue_certificate_action_non_existent_standard() -> IssueCertificate
     issuance_action.set_factory_id(FACTORY_ID.to_string());
     issuance_action.set_valid_from(1);
     issuance_action.set_valid_to(2);
+    issuance_action
+}
+
+pub fn make_update_certificate_action() -> UpdateCertificateAction {
+    let mut issuance_action = UpdateCertificateAction::new();
+    issuance_action.set_id(CERT_ID.to_string());
+    issuance_action.set_valid_from(1);
+    issuance_action.set_valid_to(3);
     issuance_action
 }
 

--- a/src/handler/test_utils.rs
+++ b/src/handler/test_utils.rs
@@ -380,11 +380,11 @@ pub fn make_issue_certificate_action_non_existent_standard() -> IssueCertificate
 }
 
 pub fn make_update_certificate_action() -> UpdateCertificateAction {
-    let mut issuance_action = UpdateCertificateAction::new();
-    issuance_action.set_id(CERT_ID.to_string());
-    issuance_action.set_valid_from(1);
-    issuance_action.set_valid_to(3);
-    issuance_action
+    let mut update_action = UpdateCertificateAction::new();
+    update_action.set_id(CERT_ID.to_string());
+    update_action.set_valid_from(1);
+    update_action.set_valid_to(3);
+    update_action
 }
 
 pub fn make_standard_create_action() -> CreateStandardAction {

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -530,6 +530,28 @@ mod tests {
     }
 
     #[test]
+    // Test creating a Update Certificate Action executes correctly
+    fn test_update_certificate_action_creation_ok() {
+        let mut new_payload = CertificateRegistryPayload::new();
+        new_payload.set_action(CertificateRegistryPayload_Action::UPDATE_CERTIFICATE);
+
+        let mut update = UpdateCertificateAction::new();
+        update.set_id("test".to_string());
+        update.set_valid_from(1);
+        update.set_valid_to(2);
+        new_payload.set_update_certificate(update.clone());
+
+        let bytes = new_payload.into_bytes().unwrap();
+
+        assert_eq!(
+            CertPayload::new(&bytes).unwrap(),
+            CertPayload {
+                action: Action::UpdateCertificate(update.clone())
+            }
+        );
+    }
+
+    #[test]
     // Test creating a Create Standard Action executes correctly
     fn test_create_standard_action_creation_ok() {
         let mut new_payload = CertificateRegistryPayload::new();

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -22,6 +22,7 @@ pub enum Action {
     UpdateOrganization(payload::UpdateOrganizationAction),
     AuthorizeAgent(payload::AuthorizeAgentAction),
     IssueCertificate(payload::IssueCertificateAction),
+    UpdateCertificate(payload::UpdateCertificateAction),
     CreateStandard(payload::CreateStandardAction),
     UpdateStandard(payload::UpdateStandardAction),
     OpenRequest(payload::OpenRequestAction),
@@ -111,6 +112,9 @@ impl CertPayload {
             }
             payload::CertificateRegistryPayload_Action::ISSUE_CERTIFICATE => {
                 validate_issue_certificate(&payload.get_issue_certificate())
+            }
+            payload::CertificateRegistryPayload_Action::UPDATE_CERTIFICATE => {
+                validate_update_certificate(&payload.get_update_certificate())
             }
             payload::CertificateRegistryPayload_Action::OPEN_REQUEST_ACTION => {
                 validate_open_request(&payload.get_open_request_action())
@@ -230,7 +234,7 @@ fn validate_issue_certificate(
         payload::IssueCertificateAction_Source::UNSET_SOURCE => {
             return Err(ApplyError::InvalidTransaction(String::from(
                 "Issue Certificate source must be set. It can be
-                FROM_REQUEST if the there is an request associated with the
+                FROM_REQUEST if there is a request associated with the
                 action, or INDEPENDENT if there is not request associated.",
             )));
         }
@@ -256,6 +260,27 @@ fn validate_issue_certificate(
 
     Ok(Action::IssueCertificate(issue_cert.clone()))
 }
+
+fn validate_update_certificate(
+    update_cert: &payload::UpdateCertificateAction,
+) -> Result<Action, ApplyError> {
+    reject_empty!(update_cert, id)?;
+
+    if update_cert.get_valid_from() == 0 {
+        return Err(ApplyError::InvalidTransaction(String::from(
+            "Certificate's valid_from field is invalid",
+        )));
+    }
+
+    if update_cert.get_valid_to() == 0 {
+        return Err(ApplyError::InvalidTransaction(String::from(
+            "Certificate's valid_to field is invalid",
+        )));
+    }
+
+    Ok(Action::UpdateCertificate(update_cert.clone()))
+}
+
 fn validate_open_request(open_request: &payload::OpenRequestAction) -> Result<Action, ApplyError> {
     reject_empty!(open_request, id, standard_id)?;
     Ok(Action::OpenRequest(open_request.clone()))


### PR DESCRIPTION
## Proposed change/fix

- [x] Implement UpdateCertificate transaction
- [x] Update Cargo.lock
- [x] Added some unit tests / update test utilities
* Minor code formatting

_Note:_ the `common` crate in the `Cargo.toml` is temporarily set to the [rsd-update-cert](https://github.com/target/consensource-common/pull/19) branch. That PR should be merged first before merging this one.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

`cargo clippy`
`cargo test`
Also tested single update txn in my local sandbox and was able to successfully update a cert (i.e. specifically it's `valid_to` date)